### PR TITLE
Model peripheral register group references

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -123,8 +123,26 @@ pub struct Module {
 pub struct Instance {
     /// The name of the peripheral instance, for example, `PORTB`.
     pub name: String,
+    /// Reference to the register group that represents this instance.
+    pub register_group_ref: Option<RegisterGroupRef>,
     /// What signals are used in the peripheral.
     pub signals: Vec<Signal>,
+}
+
+/// A refereance to a register group.
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Hash)]
+pub struct RegisterGroupRef {
+    /// The name of the register group being referenced.
+    pub name: String,
+    /// The name of the register group being referenced in the module that
+    /// defines it.
+    pub name_in_module: String,
+    /// The offset of the register group.
+    pub offset: u32,
+    /// The address space.
+    pub address_space: String,
+    /// The caption describing the register group reference.
+    pub caption: Option<String>,
 }
 
 /// A group of registers.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -153,6 +153,8 @@ fn read_variant(variant: &Element) -> Variant {
 fn read_instance(instance: &Element) -> Instance {
     let instance_name = instance.attributes.get("name").unwrap().clone();
 
+    let register_group_ref = instance.get_child("register-group").map(|e| read_register_group_ref(e));
+
     let signals = match instance.get_child("signals") {
         Some(signals) => signals
             .children
@@ -163,7 +165,7 @@ fn read_instance(instance: &Element) -> Instance {
         None => Vec::new(),
     };
 
-    Instance { name: instance_name, signals: signals }
+    Instance { name: instance_name, register_group_ref: register_group_ref, signals: signals }
 }
 
 fn read_signal(signal: &Element) -> Signal {
@@ -171,6 +173,22 @@ fn read_signal(signal: &Element) -> Signal {
         pad: signal.attributes.get("pad").unwrap().clone(),
         group: signal.attributes.get("group").map(|p| p.clone()),
         index: signal.attributes.get("index").map(|i| i.parse().unwrap()),
+    }
+}
+
+/// Reads a register group reference.
+///
+/// This looks like so
+/// ```xml
+/// <register-group address-space="data" name="PORTA" name-in-module="PORT" offset="0x0400"/>
+/// ```
+fn read_register_group_ref(register_group_ref: &Element) -> RegisterGroupRef {
+    RegisterGroupRef {
+        name: register_group_ref.attributes.get("name").unwrap().clone(),
+        name_in_module: register_group_ref.attributes.get("name-in-module").unwrap().clone(),
+        offset: read_int(register_group_ref.attributes.get("offset")).clone(),
+        address_space: register_group_ref.attributes.get("address-space").unwrap().clone(),
+        caption: register_group_ref.attributes.get("caption").map(|p| p.clone()),
     }
 }
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -183,6 +183,7 @@ fn read_signal(signal: &Element) -> Signal {
 ///   <register caption="EEPROM Address Register  Bytes" name="EEAR" offset="0x41" size="2" mask="0x01FF"/>
 ///   <register caption="EEPROM Data Register" name="EEDR" offset="0x40" size="1" mask="0xFF"/>
 /// </register-group>
+/// ```
 fn read_register_group(register_group: &Element) -> RegisterGroup {
     let (name, caption) = (
         register_group.attributes.get("name").unwrap(),


### PR DESCRIPTION
Each peripheral `Instance` has a reference to a `RegisterGroup`. I've modeled this as an optional `RegisterGroupRef` which captures the name to reference as well as offset and other details. It's optional because the Peripheral Touch Controller peripherals don't have a corresponding register group.